### PR TITLE
#1063469 Add compatibility with Redmine 6.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 gem 'after_commit_everywhere'
-gem 'commonmarker', '~> 0.23.8'
+gem 'commonmarker', '~> 2.3.0'
 gem 'jira-ruby', '~> 2.3.0', :require => 'jira-ruby'
 gem 'aasm'
 gem 'faye-websocket'

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
-gem 'dry-container', '~> 0.8.0'
-gem 'dry-configurable', '~> 0.14.0'
 gem 'after_commit_everywhere'
 gem 'commonmarker', '~> 0.23.8'
 gem 'jira-ruby', '~> 2.3.0', :require => 'jira-ruby'

--- a/README.md
+++ b/README.md
@@ -9,8 +9,12 @@ There're some built-in connectors provided with plugin, such as:
 
 ## Requirements
 
-- Redmine 4.0 or higher
-- Ruby 2.5 or higher
+- Redmine 6.0 or higher (for Rails 7.2 support)
+- Ruby 3.0 or higher
+- PostgreSQL with JSON column support (recommended) or any database with TEXT columns
+
+For legacy versions:
+- Redmine 4.0-5.x with Ruby 2.5+ (use older plugin versions)
 
 ## Installation
 
@@ -27,6 +31,52 @@ You need username and password for Jira Server(self hosted). You need username a
 
 You can find statuses from page  like https://myorgname.atlassian.net/secure/admin/ViewStatuses.jspa
 (1) Assuming you have Jira Admin rights, then you can access Jira Administration > Issues > Statuses. You can then hover the "Edit" option under the ACTION column to see each status's ID (The link should show up at the bottom left of your screen).)
+
+## Migration to Rails 7.x
+**Note**: This migration only needs to be run once when upgrading from Rails < 7.2 to Rails 7.2+.
+
+### Changes in Rails 7.2
+
+Rails 7.2 introduced changes to ActiveRecord serialization that affect this plugin:
+
+- **ActiveRecord `store` behavior changed**: No longer uses implicit YAML coder, requires explicit `coder:` parameter
+- **PostgreSQL JSON column handling**: Native JSON columns now require `store_accessor` instead of `store` to avoid double serialization
+- **Form helpers syntax**: `form_with` requires proper `fields_for` usage for nested attributes
+
+This plugin was updated to use `store_accessor` for PostgreSQL JSON columns, which is the recommended Rails 7.2+ approach.
+
+### Pre-migration Steps
+
+Before upgrading to Rails 7.2+:
+
+1. **Check your settings data** in the `bridge_integrations` table. If the `settings` field contains data in a format other than `JSON`, you need to migrate
+2. **Backup your database** - especially the `bridge_integrations` table
+
+### Migration Steps
+
+After deploying Redmine code with the updated plugin:
+
+1. **Run the data migration task**:
+   ```bash
+   cd {REDMINE_ROOT}
+   RAILS_ENV=production bundle exec rake redmine_bridge:migrate_settings_to_json
+   ```
+
+2. **Verify the migration**:
+   - Check migration output - should show: `"Migration completed"` and should't see any errors
+   - Visit `/settings/plugin/redmine_bridge` and verify all integrations are visible
+   - Edit an integration to confirm settings are preserved
+   - Test creating a new integration
+
+### Migration Task Details
+
+The migration task (`redmine_bridge:migrate_settings_to_json`) will:
+- Convert legacy YAML-serialized settings to clean JSON format
+- Preserve all existing data (statuses, priorities, connector settings)
+- Skip already-migrated records automatically
+- Report any errors during migration
+
+**Note**: This script may not account for all possible serialization duplications and other settings field format deviations that may have occurred during previous Rails updates. If for some reason you are unable to migrate your configs, you will need to either manually convert them to JSON format or delete all plugin configs and re-add them.
 
 ## License
 

--- a/app/models/bridge_integration.rb
+++ b/app/models/bridge_integration.rb
@@ -1,14 +1,18 @@
 # frozen_string_literal: true
 
 # Integration model
-class BridgeIntegration < ActiveRecord::Base
+class BridgeIntegration < ApplicationRecord
   belongs_to :project
   belongs_to :default_project, class_name: 'Project', optional: true
 
   has_many :external_issues, dependent: :destroy
   has_many :external_comments, dependent: :destroy
 
-  store :settings, accessors: %i[statuses priorities]
+  # For PostgreSQL JSON columns use store_accessor (not store)
+  # Native JSON columns don't need serialization - Rails handles it automatically
+  store_accessor :settings, :statuses, :priorities
+
+  after_initialize :set_default_settings, if: :new_record?
 
   validates :name,
             :key,
@@ -16,4 +20,11 @@ class BridgeIntegration < ActiveRecord::Base
             :project_id,
             :statuses,
             :priorities, presence: true
+
+  private
+
+  def set_default_settings
+    self.statuses ||= {}
+    self.priorities ||= {}
+  end
 end

--- a/app/models/external_comment.rb
+++ b/app/models/external_comment.rb
@@ -1,4 +1,4 @@
-class ExternalComment < ActiveRecord::Base
+class ExternalComment < ApplicationRecord
   include AASM
 
   belongs_to :redmine_journal, foreign_key: 'redmine_id', class_name: 'Journal'

--- a/app/models/external_issue.rb
+++ b/app/models/external_issue.rb
@@ -1,4 +1,4 @@
-class ExternalIssue < ActiveRecord::Base
+class ExternalIssue < ApplicationRecord
   include AASM
   # TODO: add paper_trail? or audited. Or we should make journals?
 

--- a/app/views/bridge_integrations/_form.html.erb
+++ b/app/views/bridge_integrations/_form.html.erb
@@ -12,7 +12,6 @@
       <%= form.text_field 'name' %>
     </p>
 
-
     <p>
       <%= form.label t('redmine_bridge.integration.key') %>
       <%= form.text_field 'key' %>
@@ -42,22 +41,28 @@
 
     <p><%= form.label t('redmine_bridge.integration.status_settings') + ':' %></p>
 
-    <% IssueStatus.all.each do |status| %>
-      <p>
-        <%= form.label status.name %>
-        <%= form.text_field "settings[statuses][#{status.id}]", value: @bridge_integration.settings.dig('statuses', status.id.to_s) %>
-      </p>
-    <% end %>
+    <%= form.fields_for :settings do |settings_form| %>
+      <%= settings_form.fields_for :statuses, OpenStruct.new(@bridge_integration.statuses || {}) do |statuses_form| %>
+        <% IssueStatus.all.each do |status| %>
+          <p>
+            <%= label_tag "bridge_integration_settings_statuses_#{status.id}", status.name %>
+            <%= statuses_form.text_field status.id %>
+          </p>
+        <% end %>
+      <% end %>
 
     <br>
 
-    <p><%= form.label t('redmine_bridge.integration.priority_settings') + ':' %></p>
+      <p><%= form.label t('redmine_bridge.integration.priority_settings') + ':' %></p>
 
-    <% Enumeration.where(type: 'IssuePriority').each do |enum| %>
-      <p>
-        <%= form.label enum.name %>
-        <%= form.text_field "settings[priorities][#{enum.id}]", value: @bridge_integration.settings.dig('priorities', enum.id.to_s) %>
-      </p>
+      <%= settings_form.fields_for :priorities, OpenStruct.new(@bridge_integration.priorities || {}) do |priorities_form| %>
+        <% Enumeration.where(type: 'IssuePriority').each do |enum| %>
+          <p>
+            <%= label_tag "bridge_integration_settings_priorities_#{enum.id}", enum.name %>
+            <%= priorities_form.text_field enum.id %>
+          </p>
+        <% end %>
+      <% end %>
     <% end %>
 
     <% RedmineBridge::Registry.keys.each do |key| %>

--- a/app/views/bridge_integrations/_gitlab.html.erb
+++ b/app/views/bridge_integrations/_gitlab.html.erb
@@ -1,11 +1,13 @@
 <br>
 
-<p>
-  <%= form.label 'settings[base_url]', 'Base URL' %>
-  <%= form.text_field 'settings[base_url]', value: @bridge_integration.settings['base_url'] %>
-</p>
+<%= form.fields_for :settings, OpenStruct.new(@bridge_integration.settings || {}) do |s| %>
+  <p>
+    <%= s.label :base_url, 'Base URL' %>
+    <%= s.text_field :base_url %>
+  </p>
 
-<p>
-  <%= form.label 'settings[access_token]', 'Access token' %>
-  <%= form.text_field 'settings[access_token]', value: @bridge_integration.settings['access_token'] %>
-</p>
+  <p>
+    <%= s.label :access_token, 'Access token' %>
+    <%= s.text_field :access_token %>
+  </p>
+<% end %>

--- a/app/views/bridge_integrations/_index.html.erb
+++ b/app/views/bridge_integrations/_index.html.erb
@@ -14,12 +14,12 @@
         <td><%= integration.name %></td>
         <td><%= integration.connector_id %></td>
         <td><%= integration.project.name %></td>
-        <td><%= link_to '', edit_bridge_integration_path(integration), class: 'icon icon-edit' %></td>
-        <td><%= link_to '', bridge_integration_path(integration), class: 'icon icon-del', method: :delete %></td>
+        <td><%= link_to sprite_icon('edit', l(:button_edit)), edit_bridge_integration_path(integration), class: 'icon icon-edit' %></td>
+        <td><%= link_to sprite_icon('del', l(:button_delete)), bridge_integration_path(integration), class: 'icon icon-del', method: :delete, data: { confirm: l(:text_are_you_sure) } %></td>
       </tr>
     <% end %>
   </tbody>
 </table>
 
 <br>
-<%= link_to t('redmine_bridge.new_integration'), new_bridge_integration_path, class: 'icon icon-add' %>
+<%= link_to sprite_icon('add', t('redmine_bridge.new_integration')), new_bridge_integration_path, class: 'icon icon-add' %>

--- a/app/views/bridge_integrations/_jira.html.erb
+++ b/app/views/bridge_integrations/_jira.html.erb
@@ -1,34 +1,36 @@
 <br>
 
-<p>
-  <%= form.label 'settings[jira_project_key]', 'ID проекта в Jira' %>
-  <%= form.text_field 'settings[jira_project_key]', value: @bridge_integration.settings['jira_project_key'] %>
-</p>
+<%= form.fields_for :settings, OpenStruct.new(@bridge_integration.settings || {}) do |s| %>
+  <p>
+    <%= s.label :jira_project_key, 'ID проекта в Jira' %>
+    <%= s.text_field :jira_project_key %>
+  </p>
 
-<p>
-  <%= form.label 'settings[jira_username]', 'Юзер для API' %>
-  <%= form.text_field 'settings[jira_username]', value: @bridge_integration.settings['jira_username'] %>
-</p>
+  <p>
+    <%= s.label :jira_username, 'Юзер для API' %>
+    <%= s.text_field :jira_username %>
+  </p>
 
-<p>
-  <%= form.label 'settings[jira_password]', 'Пароль(или токен) для API' %>
-  <%= form.text_field 'settings[jira_password]', type: 'password', value: @bridge_integration.settings['jira_password'] %>
-</p>
+  <p>
+    <%= s.label :jira_password, 'Пароль(или токен) для API' %>
+    <%= s.password_field :jira_password %>
+  </p>
 
-<p>
-  <%= form.label 'settings[jira_base_url]', 'Base URL хоста с JIRA' %>
-  <%= form.text_field 'settings[jira_base_url]', value: @bridge_integration.settings['jira_base_url'] %>
-</p>
+  <p>
+    <%= s.label :jira_base_url, 'Base URL хоста с JIRA' %>
+    <%= s.text_field :jira_base_url %>
+  </p>
 
-<p>
-  <%= form.label 'settings[jira_issue_type_id]', 'IssueType Id(тип, с которым будут создаваться задачи в jira)' %>
-  <%= form.text_field 'settings[jira_issue_type_id]', value: @bridge_integration.settings['jira_issue_type_id'] %>
-</p>
+  <p>
+    <%= s.label :jira_issue_type_id, 'IssueType Id(тип, с которым будут создаваться задачи в jira)' %>
+    <%= s.text_field :jira_issue_type_id %>
+  </p>
 
-<p>
-  <%= form.label 'settings[ignore_tls_errors]', 'Игнорировать ошибки TLS' %>
-  <%= form.check_box 'settings[ignore_tls_errors]', checked: @bridge_integration.settings['ignore_tls_errors'] == '1' %>
-</p>
+  <p>
+    <%= s.label :ignore_tls_errors, 'Игнорировать ошибки TLS' %>
+    <%= s.check_box :ignore_tls_errors %>
+  </p>
+<% end %>
 
 <p>
   <%= link_to t('redmine_bridge.integration.check_jira_connection'),

--- a/app/views/bridge_integrations/_mattermost.html.erb
+++ b/app/views/bridge_integrations/_mattermost.html.erb
@@ -1,56 +1,65 @@
 <br>
-<p><%= form.label t('redmine_bridge.integration.mattermost.defaults') + ':' %></p>
-<p>
-  <%= form.label 'settings[mattermost_default_tracker_id]', t('redmine_bridge.integration.mattermost.default_tracker_id') %>
-  <%= form.text_field 'settings[mattermost_default_tracker_id]', value: @bridge_integration.settings['mattermost_default_tracker_id'] %>
-</p>
-<p>
-  <%= form.label 'settings[mattermost_default_priority_id]', t('redmine_bridge.integration.mattermost.default_priority_id') %>
-  <%= form.text_field 'settings[mattermost_default_priority_id]', value: @bridge_integration.settings['mattermost_default_priority_id'] %>
-</p>
-<p>
-  <%= form.label 'settings[mattermost_default_status_id]', t('redmine_bridge.integration.mattermost.default_status_id') %>
-  <%= form.text_field 'settings[mattermost_default_status_id]', value: @bridge_integration.settings['mattermost_default_status_id'] %>
-</p>
-<p>
-  <%= form.label 'settings[mattermost_default_assignee_id]', t('redmine_bridge.integration.mattermost.default_assignee_id') %>
-  <%= form.text_field 'settings[mattermost_default_assignee_id]', value: @bridge_integration.settings['mattermost_default_assignee_id'] %>
-</p>
 
-<br>
-<p>
-  <%= form.label 'settings[mattermost_api_url]', t('redmine_bridge.integration.mattermost.api_url') %>
-  <%= form.text_field 'settings[mattermost_api_url]', value: @bridge_integration.settings['mattermost_api_url'] %>
-  <em class="info"><%= t('redmine_bridge.integration.mattermost.api_url_example') %></em>
-</p>
+<%= form.fields_for :settings, OpenStruct.new(@bridge_integration.settings || {}) do |s| %>
+  <p><%= form.label t('redmine_bridge.integration.mattermost.defaults') + ':' %></p>
 
-<p>
-  <%= form.label 'settings[mattermost_token_username]', t('redmine_bridge.integration.mattermost.username') %>
-  <%= form.text_field 'settings[mattermost_token_username]', value: @bridge_integration.settings['mattermost_token_username'] %>
-</p>
+  <p>
+    <%= s.label :mattermost_default_tracker_id, t('redmine_bridge.integration.mattermost.default_tracker_id') %>
+    <%= s.text_field :mattermost_default_tracker_id %>
+  </p>
 
-<p>
-  <%= form.label 'settings[mattermost_token_id]', t('redmine_bridge.integration.mattermost.token_id') %>
-  <%= form.text_field 'settings[mattermost_token_id]', value: @bridge_integration.settings['mattermost_token_id'] %>
-</p>
+  <p>
+    <%= s.label :mattermost_default_priority_id, t('redmine_bridge.integration.mattermost.default_priority_id') %>
+    <%= s.text_field :mattermost_default_priority_id %>
+  </p>
 
-<p>
-  <%= form.label 'settings[mattermost_access_token]', t('redmine_bridge.integration.mattermost.access_token') %>
-  <%= form.text_field 'settings[mattermost_access_token]', type: 'password', value: @bridge_integration.settings['mattermost_access_token'] %>
-</p>
+  <p>
+    <%= s.label :mattermost_default_status_id, t('redmine_bridge.integration.mattermost.default_status_id') %>
+    <%= s.text_field :mattermost_default_status_id %>
+  </p>
 
-<p>
-  <%= form.label 'settings[mattermost_team_id]', t('redmine_bridge.integration.mattermost.team_id')  %>
-  <%= form.text_field 'settings[mattermost_team_id]', value: @bridge_integration.settings['mattermost_team_id'] %>
-</p>
+  <p>
+    <%= s.label :mattermost_default_assignee_id, t('redmine_bridge.integration.mattermost.default_assignee_id') %>
+    <%= s.text_field :mattermost_default_assignee_id %>
+  </p>
 
-<p>
-  <%= form.label 'settings[mattermost_author_id]', t('redmine_bridge.integration.mattermost.author_id')  %>
-  <%= select_tag 'bridge_integration[settings[mattermost_author_id]]',
-        options_for_select(User.order(%w(lastname firstname id)).visible.map{|u| [u.name, u.id]}, @bridge_integration.settings['mattermost_author_id'].to_s) %>
-</p>
+  <br>
 
-<p>
-  <%= form.label 'settings[mattermost_locale]', t('redmine_bridge.integration.mattermost.messages_locale')  %>
-  <%= select_tag 'bridge_integration[settings[mattermost_locale]]', options_for_select(lang_options_for_select(false), @bridge_integration.settings['mattermost_locale'].to_s) %>
-</p>
+  <p>
+    <%= s.label :mattermost_api_url, t('redmine_bridge.integration.mattermost.api_url') %>
+    <%= s.text_field :mattermost_api_url %>
+    <em class="info"><%= t('redmine_bridge.integration.mattermost.api_url_example') %></em>
+  </p>
+
+  <p>
+    <%= s.label :mattermost_token_username, t('redmine_bridge.integration.mattermost.username') %>
+    <%= s.text_field :mattermost_token_username %>
+  </p>
+
+  <p>
+    <%= s.label :mattermost_token_id, t('redmine_bridge.integration.mattermost.token_id') %>
+    <%= s.text_field :mattermost_token_id %>
+  </p>
+
+  <p>
+    <%= s.label :mattermost_access_token, t('redmine_bridge.integration.mattermost.access_token') %>
+    <%= s.password_field :mattermost_access_token %>
+  </p>
+
+  <p>
+    <%= s.label :mattermost_team_id, t('redmine_bridge.integration.mattermost.team_id') %>
+    <%= s.text_field :mattermost_team_id %>
+  </p>
+
+  <p>
+    <%= s.label :mattermost_author_id, t('redmine_bridge.integration.mattermost.author_id') %>
+    <%= s.select :mattermost_author_id,
+        User.order(%w(lastname firstname id)).visible.map{|u| [u.name, u.id]},
+        { include_blank: true } %>
+  </p>
+
+  <p>
+    <%= s.label :mattermost_locale, t('redmine_bridge.integration.mattermost.messages_locale') %>
+    <%= s.select :mattermost_locale, lang_options_for_select(false), { include_blank: true } %>
+  </p>
+<% end %>

--- a/init.rb
+++ b/init.rb
@@ -20,7 +20,7 @@ Redmine::Plugin.register :redmine_bridge do
   name 'Redmine Bridge'
   author 'Slurm'
   description 'This is a plugin for Redmine'
-  version '1.0.1'
+  version '2.0.1'
   url 'https://github.com/southbridgeio/redmine_bridge'
   author_url 'https://slurm.io'
 

--- a/lib/omni_markup.rb
+++ b/lib/omni_markup.rb
@@ -1,6 +1,8 @@
+require 'commonmarker'
+
 class OmniMarkup
   def self.from_gitlab_markdown(text)
-    new(Nokogiri::HTML.fragment(CommonMarker.render_html(text).gsub("<br />\n", "<br />")))
+    new(Nokogiri::HTML.fragment(Commonmarker.to_html(text).gsub("<br />\n", "<br />")))
   end
 
   def self.from_redmine_textile(text)

--- a/lib/redmine_bridge/gitlab_connector.rb
+++ b/lib/redmine_bridge/gitlab_connector.rb
@@ -6,16 +6,16 @@ class RedmineBridge::GitlabConnector
                                                           access_token: settings['access_token'])
       end
 
-      def update_gitlab_issue(*args)
+      def update_gitlab_issue(project_id, issue_iid, **params)
         return if settings.values_at('base_url', 'access_token').any?(&:blank?)
 
-        gitlab_client.update_issue(*args)
+        gitlab_client.update_issue(project_id, issue_iid, **params)
       end
 
-      def create_discussion(*args)
+      def create_discussion(project_id, issue_iid, **params)
         return if settings.values_at('base_url', 'access_token').any?(&:blank?)
 
-        gitlab_client.create_discussion(*args)
+        gitlab_client.create_discussion(project_id, issue_iid, **params)
       end
     end
   end
@@ -68,7 +68,7 @@ class RedmineBridge::GitlabConnector
 
     return if gitlab_params.blank?
 
-    integration.update_gitlab_issue(project_id, issue_iid, gitlab_params)
+    integration.update_gitlab_issue(project_id, issue_iid, **gitlab_params)
   end
 
   def check_connection

--- a/lib/redmine_bridge/hooks/controller_issue_hook.rb
+++ b/lib/redmine_bridge/hooks/controller_issue_hook.rb
@@ -4,7 +4,8 @@ module RedmineBridge
       include AfterCommitEverywhere
 
       # after issue creation
-      def controller_issues_new_after_save(issue:, **)
+      def controller_issues_new_after_save(context = {})
+        issue = context[:issue]
         bridge_integrations = BridgeIntegration.where(project_id: issue.project_id)
         return unless bridge_integrations.present?
 
@@ -20,7 +21,9 @@ module RedmineBridge
       end
 
       # after issue updation(comments also here)
-      def controller_issues_edit_after_save(issue:, journal:, **)
+      def controller_issues_edit_after_save(context = {})
+        issue = context[:issue]
+        journal = context[:journal]
         return unless journal.id
 
         bridge_integrations = BridgeIntegration.where(project_id: issue.project_id)
@@ -40,7 +43,8 @@ module RedmineBridge
       end
 
       # here only comments editing(not creation)
-      def controller_journals_edit_post(journal:, **)
+      def controller_journals_edit_post(context = {})
+        journal = context[:journal]
         issue = journal.issue
 
         bridge_integrations = BridgeIntegration.where(project_id: issue.project_id)

--- a/lib/redmine_bridge/issue_repository.rb
+++ b/lib/redmine_bridge/issue_repository.rb
@@ -3,7 +3,7 @@ class RedmineBridge::IssueRepository
     @integration = integration
   end
 
-  def create(external_attributes, test, **params)
+  def create(external_attributes, test: false, **params)
     status_id = integration.statuses.reject { |_k, v| v.blank? }.invert[external_attributes.status_id.to_s]
     priority_id = integration.priorities.reject { |_k, v| v.blank? }.invert[external_attributes.priority_id.to_s]
 

--- a/lib/redmine_bridge/mattermost_connector.rb
+++ b/lib/redmine_bridge/mattermost_connector.rb
@@ -121,7 +121,7 @@ class RedmineBridge::MattermostConnector
      #{extra}"
   end
 
-  def create_issue(**attrs)
+  def create_issue(attrs)
     issue = Issue.create!(project: attrs[:project],
                           tracker: attrs[:tracker],
                           status_id: attrs[:status_id],

--- a/lib/redmine_bridge/mattermost_connector.rb
+++ b/lib/redmine_bridge/mattermost_connector.rb
@@ -3,7 +3,7 @@ class RedmineBridge::MattermostConnector
 
   ACCIDENT_PRIORITY = 14
 
-  def initialize(integration:, logger: Rails.logger)
+  def initialize(logger: Rails.logger, integration:)
     @logger = logger
     @integration = integration
     @settings = integration.settings

--- a/lib/redmine_bridge/prometheus_connector.rb
+++ b/lib/redmine_bridge/prometheus_connector.rb
@@ -63,7 +63,7 @@ class RedmineBridge::PrometheusConnector
         )
 
         issue_repository.create(external_attributes,
-                                test,
+                                test: test,
                                 project_id: project_id,
                                 subject: subject,
                                 description: text,

--- a/lib/redmine_bridge/registry.rb
+++ b/lib/redmine_bridge/registry.rb
@@ -1,10 +1,21 @@
 # Registry for integration plugins
-# Redmine bridge contain only Jira connector
+# Redmine bridge contains connectors for Jira, Prometheus, GitLab, Mattermost
 module RedmineBridge::Registry
-  extend Dry::Container::Mixin
+  CONNECTORS = {
+    jira: ->(**kwargs) { RedmineBridge::JiraConnector.new(**kwargs) },
+    prometheus: ->(**kwargs) { RedmineBridge::PrometheusConnector.new(**kwargs) },
+    gitlab: ->(**kwargs) { RedmineBridge::GitlabConnector.new(**kwargs) },
+    mattermost: ->(**kwargs) { RedmineBridge::MattermostConnector.new(**kwargs) }
+  }.freeze
 
-  register :jira, ->(*args) { RedmineBridge::JiraConnector.new(*args) }
-  register :prometheus, ->(*args) { RedmineBridge::PrometheusConnector.new(*args) }
-  register :gitlab, ->(*args) { RedmineBridge::GitlabConnector.new(*args) }
-  register :mattermost, ->(*args) { RedmineBridge::MattermostConnector.new(*args) }
+  def self.[](key)
+    connector = CONNECTORS[key.to_sym]
+    raise KeyError, "Unknown connector: #{key}" unless connector
+
+    connector
+  end
+
+  def self.keys
+    CONNECTORS.keys
+  end
 end

--- a/lib/redmine_bridge/runners/mattermost.rb
+++ b/lib/redmine_bridge/runners/mattermost.rb
@@ -1,7 +1,7 @@
 class RedmineBridge::Runners::Mattermost
   RECONNECT_TIME = 10
 
-  def initialize(integration:, logger: Rails.logger)
+  def initialize(logger: Rails.logger, integration:)
     @logger = logger
     @integration = integration
     @settings = integration.settings

--- a/lib/tasks/migrate_settings_to_json.rake
+++ b/lib/tasks/migrate_settings_to_json.rake
@@ -1,0 +1,41 @@
+namespace :redmine_bridge do
+  desc 'Migrate settings from YAML to JSON format (Rails 7.2 compatibility)'
+  task migrate_settings_to_json: :environment do
+    puts "=" * 80
+    puts "Migrating BridgeIntegration settings: YAML → JSON"
+    puts "=" * 80
+    puts ""
+
+    success_count = 0
+    error_count = 0
+    skipped_count = 0
+
+    BridgeIntegration.find_each do |integration|
+      begin
+        raw_settings = integration.read_attribute_before_type_cast(:settings)
+
+        if raw_settings.start_with?('{') || raw_settings.start_with?('[')
+          puts "Integration ##{integration.id} (#{integration.name}): already in JSON format"
+          skipped_count += 1
+          next
+        end
+
+        settings_hash = YAML.load(integration.settings, permitted_classes: [ActiveSupport::HashWithIndifferentAccess])
+        integration.update(settings: settings_hash)
+
+        puts "Integration ##{integration.id} (#{integration.name}): migrated"
+        success_count += 1
+      rescue => e
+        puts "Integration ##{integration.id} (#{integration.name}): ERROR - #{e.message}"
+        error_count += 1
+      end
+    end
+
+    puts "=" * 80
+    puts "Migration completed"
+    puts "=" * 80
+    puts "Migrated: #{success_count}"
+    puts "Skipped: #{skipped_count}"
+    puts "Errors: #{error_count}"
+  end
+end


### PR DESCRIPTION
- Add compatibility with Redmine 6.1
- Add compatibility with ruby 3.2; 
- Remove redundant dependencies with dry-container and dry-configurable gems
- Add rake task to migrate `settings` data in the correct JSON format for compatibility with Rails 7.2.

https://factory.southbridge.io/issues/1148595