### PR TITLE
(#1168321) Fix early return in bridge hook breaking bridge_integrations loop

### DIFF
--- a/lib/redmine_bridge/hooks/controller_issue_hook.rb
+++ b/lib/redmine_bridge/hooks/controller_issue_hook.rb
@@ -30,7 +30,7 @@ module RedmineBridge
           # could be nil if we change some old issue(which exist in our project,
           # but does not exist in external)
           external_issue = ExternalIssue.find_by(redmine_id: issue.id, connector_id: bridge_integration.connector_id)
-          return unless external_issue
+          next unless external_issue
 
           # TODO: temporal for migration period before old data will be updated.
           external_issue.bridge_integration = bridge_integration


### PR DESCRIPTION
https://factory.southbridge.io/issues/1168321

Return caused the loop to exit if there was no `external_issue` for the integration. This could cause some updates to not be processed, as an integration without a corresponding external_issue would appear earlier in the list than the one it was supposed to be processed for.

This likely caused a bug with the Mattermost integration from this ticket. The project contained three Bridge integrations, but the corresponding ExternalIssue for a specific Redmine task was only available for the Mattermost connector.

Replaced `return` with `next` in controller_issues_edit_after_save
to allow all integrations to process issue updates, not just the
first one with an ExternalIssue record.